### PR TITLE
Install a DNS Resolver and Consul Template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,23 @@
 FROM gliderlabs/alpine:3.4
 MAINTAINER Devops Team <devops@bandsintown.com>
 
+ENV S6_OVERLAY_VERSION=1.18.1.5 GODNSMASQ_VERSION=1.0.7 CONSUL_TEMPLATE_VERSION=0.16.0
+
 # Install root filesystem
 ADD ./rootfs /
 
 # Install base packages
 RUN apk update && apk upgrade && \
     apk-install curl wget bash tree && \
-    echo -ne "Alpine Linux 3.4 image. (`uname -rsv`)\n" >> /root/.built
+    curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz | tar -xz -C / && \
+    curl -Ls https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip -o consul-template.zip && unzip consul-template.zip -d /usr/local/bin && \
+    curl -Ls https://github.com/janeczku/go-dnsmasq/releases/download/${GODNSMASQ_VERSION}/go-dnsmasq-min_linux-amd64 -o /usr/sbin/go-dnsmasq &&  \
+    rm -f consul-template* && \
+    chmod +x /usr/sbin/go-dnsmasq && \
+    echo -ne "Alpine Linux 3.4 image. (`uname -rsv`)\n" >> /root/.built && \
+    echo -ne "- with S6 Overlay: $S6_OVERLAY_VERSION, Go DNS Mask: $GODNSMASQ_VERSION, Consul Template: $CONSUL_TEMPLATE_VERSION\n" >> /root/.built
 
+
+#ENTRYPOINT ["/init"]
 # Define bash as default command
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -2,37 +2,112 @@
 
 ![logo](https://github.com/bandsintown-canada/docker-alpine/blob/latest/logo.png)
 
-[Alpine Linux](http://alpinelinux.org/) is a Linux distribution built around [musl libc](http://www.musl-libc.org/) and [BusyBox](http://www.busybox.net/).
+[Alpine Linux](http://alpinelinux.org/) is a very small Linux distribution built around [musl libc](http://www.musl-libc.org/) and [BusyBox](http://www.busybox.net/).
 
-This image is based on the well tested and documented [gliderlabs/alpine](http://gliderlabs.viewdocs.io/docker-alpine/) image.
 This makes Alpine Linux a great image base for utilities and even production applications. [Read more about Alpine Linux here](https://www.alpinelinux.org/about/) and you can see how their mantra fits in right at home with Docker images.
 
-# Included packages
 
-To get you started, a set of packages have been integrated:
+# About
 
-- curl
-- wget
-- ca-certificates
-- bash
-- tree
+This image is derived from the well tested and documented [Alpine Docker image](http://gliderlabs.viewdocs.io/docker-alpine/) image adding: 
+ - the [s6 supervisor for containers](https://github.com/just-containers/s6-overlay) 
+ - a lightweight [DNS resolver](https://github.com/janeczku/go-dnsmasq) with minimal runtime and filesystem overhead 
+ - [Consul Template](https://github.com/hashicorp/consul-template) for service discovery and configuration management
+ - some useful packages: `bash`, `tree`, `curl`, `wget`
+
+## Motivation
+
+Alpine Linux does not support the `search` keyword in resolv.conf. This breaks many tools that rely on DNS service discovery (e.g. Kubernetes, Tutum.co, Consul).
+
+Additionally Alpine Linux deviates from the established concept of primary and secondary nameservers. This leads to problems in cases where the container is configured with multiple nameserver with inconsistent records (e.g. one Consul server and one recursing server).
+    
+To overcome these issues the image includes a lightweight (1.2 MB) container-only [DNS resolver](https://github.com/janeczku/go-dnsmasq) that replicates the behavior of GNU libc's stub-resolver.
+
+## How it works
+
+On container start the DNS resolver parses the `nameserver` and `search` entries from `resolv.conf` and configures itself as nameserver for the container. DNS queries from local processes are handled following these conventions:
+* The nameserver listed first in resolv.conf is always queried first. Additional nameservers are treated as fallbacks.
+* Hostnames are qualified by appending the domains configured with the `search` keyword in resolv.conf
+* Single-label hostnames (e.g.: "redis-master") are always qualified with search domains
+* Multi-label hostnames are first tried as absolute names and only then qualified with search domains
+
 
 # Usage
 
-Use this as base for your own containers:
+The official Alpine Docker image is well documented, so check out [their documentation](http://gliderlabs.viewdocs.io/docker-alpine) to learn more about building micro Docker images with Alpine Linux.
 
-```
+# Basic usage    
+Building your own image based on this image is as easy as:
+
+
+```Dockerfile
 FROM bandsintown/alpine
 RUN apk-install <package_name>
 
 CMD ["/bin/bash"]
 ```
 
-or run it directly :
+or :
 
 ```
 docker run -ti bandsintown/alpine
 ```
+
+## Supervised usage
+
+By default the [s6 supervisor](https://github.com/just-containers/s6-overlay) is not enabled because the `ENTRYPOINT` is not defined.
+
+To use s6 as a supervisor and enabling the pre-bundled services 
+([DNS resolver](https://github.com/janeczku/go-dnsmasq)  and [Consul Template](https://github.com/hashicorp/consul-template)) 
+you have to define an `entrypoint`: 
+
+```Dockerfile
+FROM bandsintown/alpine
+RUN apk-install <package_name>
+
+ENTRYPOINT ["/init"]
+CMD ["/bin/bash"]
+```
+
+or :
+
+```
+docker run -ti --entrypoint=/init bandsintown/alpine bash 
+```
+
+## Manage services
+
+### DNS resolver
+
+In the case you need to disable the [DNS resolver](https://github.com/janeczku/go-dnsmasq) you can just pass the environment variable `DISABLE_DNSMASQ`:
+
+```
+docker run -ti --entrypoint=/init -e DISABLE_DNSMASQ=true bandsintown/alpine bash 
+```
+
+### Consul Template
+
+In the case you need to disable [Consul Template](https://github.com/hashicorp/consul-template) you can just pass the environment variable `DISABLE_CONSUL_TEMPLATE`:
+
+```
+docker run -ti --entrypoint=/init -e DISABLE_CONSUL_TEMPLATE=true bandsintown/alpine bash 
+```
+
+The `CONSUL_ADDRESS` might be passed as an environment variable to define the address of Consul:
+
+```
+docker run -ti --entrypoint=/init -e CONSUL_ADDRESS=demo.consul.io bandsintown/alpine bash 
+```
+
+
+Alternatively if you run your containers on AWS and you need to get the host IP, you can use the variable `RUN_ON_AWS`:
+
+```
+docker run -ti --entrypoint=/init -e RUN_ON_AWS=true bandsintown/alpine bash 
+```
+
+The configuration of Consul template must be located in `/etc/consul-template/conf`.
+
 
 # Build
 

--- a/rootfs/etc/services.d/consul-template/finish
+++ b/rootfs/etc/services.d/consul-template/finish
@@ -1,0 +1,7 @@
+#!/usr/bin/execlineb -S1
+
+# only tell s6 to bring down the entire container, if it isn't already doing so
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/rootfs/etc/services.d/consul-template/run
+++ b/rootfs/etc/services.d/consul-template/run
@@ -1,0 +1,30 @@
+#!/usr/bin/execlineb -P
+
+if { s6-svwait -t 5000 -u /var/run/s6/services/go-dnsmasq }
+with-contenv
+backtick -D "" -n DISABLE_CONSUL_TEMPLATE { printcontenv DISABLE_CONSUL_TEMPLATE }
+importas -u DISABLE_CONSUL_TEMPLATE DISABLE_CONSUL_TEMPLATE
+ifelse { s6-test -n ${DISABLE_CONSUL_TEMPLATE} }
+{
+    fdmove -c 2 1
+	tail -f /dev/null
+}
+
+backtick -D "" -n RUN_ON_AWS { printcontenv RUN_ON_AWS }
+importas -u RUN_ON_AWS RUN_ON_AWS
+backtick -D "" -n CONSUL_ADDRESS { printcontenv CONSUL_ADDRESS }
+importas -u CONSUL_ADDRESS CONSUL_ADDRESS
+
+ifelse { s6-test -n ${RUN_ON_AWS} }
+{
+    # Resolve the EC2 IP running a Consul Agent through API
+    # We assume the port is the default one (8500)
+    HOST_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+    CONSUL_ADDRESS="$HOST_IP:8500"
+}
+
+ifelse { s6-test -d /etc/consul-template/conf }
+{
+    fdmove -c 2 1
+    consul-template -consul ${CONSUL_ADDRESS} -config "/etc/consul-template/conf"
+}

--- a/rootfs/etc/services.d/go-dnsmasq/finish
+++ b/rootfs/etc/services.d/go-dnsmasq/finish
@@ -1,0 +1,7 @@
+#!/usr/bin/execlineb -S1
+
+# only tell s6 to bring down the entire container, if it isn't already doing so
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/rootfs/etc/services.d/go-dnsmasq/run
+++ b/rootfs/etc/services.d/go-dnsmasq/run
@@ -1,0 +1,12 @@
+#!/usr/bin/execlineb -P
+
+with-contenv
+backtick -D "" -n DISABLE_DNSMASQ { printcontenv DISABLE_DNSMASQ }
+importas -u DISABLE_DNSMASQ DISABLE_DNSMASQ
+ifelse { s6-test -n ${DISABLE_DNSMASQ} }
+{
+    fdmove -c 2 1
+	tail -f /dev/null
+}
+fdmove -c 2 1
+go-dnsmasq --default-resolver --enable-search --hostsfile=/etc/hosts


### PR DESCRIPTION
Hi guys,

This pull request is very important for what we are building. 

Basically in this PR, I installed go-dnsmasq and Consul template supervised by S6, in order to be able to resolve DNS names through Consul on our ECS infrastructure.

Please take time to check the [README.md](https://github.com/nhuray/docker-alpine/blob/85b2339f7bf8e43ba38890294b86befa927336b5/README.md) to understand the motivation for this change.

Nik