### PR TITLE
Consul supervised service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v1.0.4 (April 24, 2017) 
+
+### Packages installed
+
+The following package has been added:
+  - `gettext`
+  
+### Services installed
+
+The following services can be started :
+  - `Consul`: Run consul agent defining the configuration in `/etc/consul` when setting `ENABLE_CONSUL=true`
+  
 ## v1.0.3 (April 20, 2017) 
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This image is derived from the well tested and documented [Alpine Docker image](
  - the [s6 supervisor for containers](https://github.com/just-containers/s6-overlay) 
  - a lightweight [DNS resolver](https://github.com/janeczku/go-dnsmasq) with minimal runtime and filesystem overhead 
  - [Consul Template](https://github.com/hashicorp/consul-template) for service discovery and configuration management
- - some useful packages: `bash`, `tree`, `curl`, `wget`, 
+ - some useful packages: `bash`, `tree`, `curl`, `wget`, `su-exec`, `gettext`
  - since 3.5 this packages have been added:`jq`, `bind-tools`, `consul`
 
 ## Motivation
@@ -111,6 +111,18 @@ docker run -ti --entrypoint=/init -e RUN_ON_AWS=true bandsintown/alpine bash
 ```
 
 The configuration of Consul template must be located in `/etc/consul-template/conf`.
+
+## Consul agent
+
+In some scenarios we need to run a Consul agent into the container in order to join a Consul server or agent.
+
+For this need it's possible to enable consul as a service managed by S6 doing:
+
+```
+docker run -ti --entrypoint=/init -e ENABLE_CONSUL=true my-image-with-consul-config bash 
+```
+
+A consul configuration MUST be defined in `/etc/consul` directory and the configuration files can use bash environment variables.
 
 
 # Build

--- a/bin/alpine
+++ b/bin/alpine
@@ -169,7 +169,7 @@ VERSIONS=($(ls $BASE_DIR/versions))
 IMAGE="bandsintown/alpine"
 IMAGE_TEST="$IMAGE-test"
 BUILD_NUM="$(git rev-parse --short HEAD)"
-TESTS=(test-image test-dns test-dns-multiple test-consul-template)
+TESTS=(test-image test-dns test-dns-multiple test-consul-template test-consul)
 
 # Check programs needed to tests are installed
 type docker >/dev/null 2>&1 || { error "Please install Docker to run tests."; exit 1;}

--- a/debug.yml
+++ b/debug.yml
@@ -43,3 +43,13 @@ services:
     volumes:
       - ./tests:/tests
       - ./tests/consul-template/etc:/etc/consul-template
+
+
+  # Test debug for consul
+  test-consul:
+    command: bash
+    stdin_open: true
+    tty: true
+    working_dir: /tests/consul
+    volumes:
+      - ./tests:/tests

--- a/rootfs/etc/cont-init.d/01-environment
+++ b/rootfs/etc/cont-init.d/01-environment
@@ -8,4 +8,5 @@ EC2_IP="$(curl -s --connect-timeout 5 http://169.254.169.254/latest/meta-data/lo
 if [ -n "${EC2_IP}" ]; then
   echo -n "${EC2_IP}" > /var/run/s6/container_environment/EC2_IP
   test -n "${CONSUL_ADDRESS}" || echo -n "${EC2_IP}:${CONSUL_PORT:-8500}" > /var/run/s6/container_environment/CONSUL_ADDRESS
+  test -n "${CONSUL_SERF_ADDRESS}" || echo -n "${EC2_IP}:${CONSUL_SERF_PORT:-8301}" > /var/run/s6/container_environment/CONSUL_SERF_ADDRESS
 fi

--- a/rootfs/etc/services.d/consul/finish
+++ b/rootfs/etc/services.d/consul/finish
@@ -1,0 +1,7 @@
+#!/usr/bin/execlineb -S1
+
+# only tell s6 to bring down the entire container, if it isn't already doing so
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/rootfs/etc/services.d/consul/run
+++ b/rootfs/etc/services.d/consul/run
@@ -1,0 +1,14 @@
+#!/usr/bin/with-contenv sh
+
+if [ "${ENABLE_CONSUL}" = "true" ] && [ -d /etc/consul ]; then
+  # Environment variables interpolation
+  for file in $(ls /etc/consul); do
+    content=$(cat /etc/consul/$file | envsubst)
+    rm -f $file
+    echo "$content" > /etc/consul/$file
+  done
+
+  # Run consul agent
+  su-exec ${CONSUL_TEMPLATE_USER:-root} \
+     consul agent -config-dir /etc/consul
+fi

--- a/tests.yml
+++ b/tests.yml
@@ -49,12 +49,27 @@ services:
       - CONSUL_SERF_ADDRESS=consul:8301
       - VERSION=${VERSION}
 
+  # Tests for consul managed by S6
+  test-consul:
+    image: bandsintown/alpine-test:${VERSION}
+    command: dockerize -wait http://consul:8500 -timeout 10s bats /tests/consul
+    depends_on:
+      - consul
+    environment:
+      - DISABLE_CONSUL_TEMPLATE=true
+      - ENABLE_CONSUL=true
+      - CONSUL_ADDRESS=consul:8500
+      - CONSUL_SERF_ADDRESS=consul:8301
+      - VERSION=${VERSION}
+
   # Consul
   consul:
     image: consul
     command: "agent -dev -client 0.0.0.0 -ui"
     ports:
       - 8500
+      - 8600
+      - 8301
     environment:
       - CONSUL_BIND_INTERFACE=eth0
 

--- a/tests.yml
+++ b/tests.yml
@@ -7,12 +7,13 @@ services:
   # Test image (packages, services, scripts)
   test-image:
     image: bandsintown/alpine-test:${VERSION}
-    command: dockerize -wait http://test-consul:8500 -timeout 10s bats /tests/image
+    command: dockerize -wait http://consul:8500 -timeout 10s bats /tests/image
     depends_on:
-      - test-consul
+      - consul
     environment:
       - VERSION=${VERSION}
-      - CONSUL_ADDRESS=test-consul:8500
+      - CONSUL_ADDRESS=consul:8500
+      - CONSUL_SERF_ADDRESS=consul:8301
 
   # Tests with only one DNS Nameserver and Search Domain
   test-dns:
@@ -39,16 +40,17 @@ services:
   # Tests for consul template
   test-consul-template:
     image: bandsintown/alpine-test:${VERSION}
-    command: dockerize -wait http://test-consul:8500 -timeout 10s bats /tests/consul-template
+    command: dockerize -wait http://consul:8500 -timeout 10s bats /tests/consul-template
     depends_on:
-      - test-consul
+      - consul
     environment:
       - DISABLE_CONSUL_TEMPLATE=true
-      - CONSUL_ADDRESS=test-consul:8500
+      - CONSUL_ADDRESS=consul:8500
+      - CONSUL_SERF_ADDRESS=consul:8301
       - VERSION=${VERSION}
 
   # Consul
-  test-consul:
+  consul:
     image: consul
     command: "agent -dev -client 0.0.0.0 -ui"
     ports:

--- a/tests/consul-template/01-consul.bats
+++ b/tests/consul-template/01-consul.bats
@@ -2,6 +2,6 @@
 
 @test "Check consul is up and running" {
   # Check Consul is reachable
-  run curl http://test-consul:8500/v1/catalog/service/consul
+  run curl http://consul:8500/v1/catalog/service/consul
   [ "$status" -eq 0 ]
 }

--- a/tests/consul-template/01-consul.bats
+++ b/tests/consul-template/01-consul.bats
@@ -1,7 +1,9 @@
 #!/usr/bin/env bats
 
+consul_service="consul"
+
 @test "Check consul is up and running" {
   # Check Consul is reachable
-  run curl http://consul:8500/v1/catalog/service/consul
+  run curl http://${consul_service}:8500/v1/catalog/service/consul
   [ "$status" -eq 0 ]
 }

--- a/tests/consul-template/02-consul-template.bats
+++ b/tests/consul-template/02-consul-template.bats
@@ -3,7 +3,7 @@ load helpers
 
 # Declare the service
 service=test-api
-consul_service="test-consul"
+consul_service="consul"
 address="$(dig +short ${consul_service})"
 port="8500"
 

--- a/tests/consul/01-consul.bats
+++ b/tests/consul/01-consul.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+consul_service="consul"
+
+@test "Check consul is up and running" {
+  test $(bc <<< "$VERSION >= 3.5") -eq 0 && skip "Consul not installed in this version"
+
+  # Check Consul is reachable
+  run curl http://${consul_service}:8500/v1/catalog/service/consul
+  [ "$status" -eq 0 ]
+}
+
+@test "Check consul agent service has joined consul server container" {
+   test $(bc <<< "$VERSION >= 3.5") -eq 0 && skip "Consul not installed in this version"
+
+   # Sleep to prevent race conditions
+   sleep 2
+
+   # Check consul service has joined consul server container
+   status="$(cat /var/log/s6-uncaught-logs/current  | grep 'adding server' 2>&1 > /dev/null; echo $?)"
+   [ "$status" -eq 0 ]
+}

--- a/tests/consul/etc/tests.json
+++ b/tests/consul/etc/tests.json
@@ -1,0 +1,8 @@
+{
+    "datacenter": "dc1",
+    "data_dir": "/var/lib/consul",
+    "retry_join": [
+        "$CONSUL_SERF_ADDRESS"
+    ],
+    "retry_max": 2
+}

--- a/tests/consul/helpers.bash
+++ b/tests/consul/helpers.bash
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+function require_env {
+    if [[ -z ${!1} ]]; then
+        errecho "This test requires the $1 environment variable to be set in order to run."
+        exit 1
+    fi
+}
+
+function register_service {
+    require_env CONSUL_ADDRESS
+    service=$1
+    tag=$2
+    local payload=$(curl -s http://${CONSUL_ADDRESS}/v1/catalog/service/consul | jq -r '.[] | {  address: .Address, port:.ServicePort}')
+    address=$(echo ${payload} | jq -r '.address')
+
+body=$(cat << EOF
+{
+  "Datacenter": "dc1",
+  "Node": "node-$service",
+  "Address": "$address",
+  "Service": {
+    "ID": "$service",
+    "Service": "$service",
+    "Address": "$address",
+    "Port": 8500,
+    "Tags": ["$tag"]
+  },
+  "Check": {
+    "Node": "node-$service",
+    "CheckID": "service:$service",
+    "Name": "Health check for service $service",
+    "Notes": "Script based health check",
+    "Status": "passing",
+    "ServiceID": "$service"
+  }
+}
+EOF
+)
+    echo "Registering service '$service' (Address : $address, Port: 8500, Tag: $tag)"
+    curl -H 'Content-Type: application/json' -XPUT -d "${body}" http://${CONSUL_ADDRESS}/v1/catalog/register
+}
+
+function register_key {
+    require_env CONSUL_ADDRESS
+
+    key=$1
+    value=$2
+
+    echo "Registering key '$key'"
+    curl -s -H 'Content-Type: application/json' -XPUT -d "${value}" "http://${CONSUL_ADDRESS}/v1/kv/$key"  > /dev/null
+}
+
+function random_ip {
+    echo $(dd if=/dev/urandom bs=4 count=1 2>/dev/null | od -An -tu1 | sed -e 's/^ *//' -e 's/  */./g')
+}
+
+function random_port {
+    echo $(shuf -i30000-50000 -n1)
+}

--- a/tests/image/02-packages.bats
+++ b/tests/image/02-packages.bats
@@ -65,3 +65,9 @@
   result=$(stat -c "%a" $(which su-exec))
   [ $result -eq 4755 ]
 }
+
+
+@test "package 'gettext' should be present" {
+  run which envsubst
+  [ $status -eq 0 ]
+}

--- a/tests/image/04-environment.bats
+++ b/tests/image/04-environment.bats
@@ -7,3 +7,8 @@
   run test -n "${CONSUL_ADDRESS}"
   [ $status -eq 0 ]
 }
+
+@test "environment variable 'CONSUL_SERF_ADDRESS' is set" {
+  run test -n "${CONSUL_SERF_ADDRESS}"
+  [ $status -eq 0 ]
+}

--- a/versions/3.4/Dockerfile
+++ b/versions/3.4/Dockerfile
@@ -12,7 +12,7 @@ ADD ./rootfs /
 
 # Install base packages
 RUN apk update && apk upgrade && \
-    apk-install curl wget bash tree su-exec && \
+    apk-install curl wget bash tree su-exec gettext && \
     chmod u+s /sbin/su-exec && \
     curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz | tar -xz -C / && \
     curl -Ls https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip -o consul-template.zip && unzip consul-template.zip -d /usr/local/bin && \

--- a/versions/3.5/Dockerfile
+++ b/versions/3.5/Dockerfile
@@ -12,7 +12,7 @@ COPY rootfs /
 
 # Install base packages
 RUN apk update && apk upgrade && \
-    apk-install curl wget bash tree jq bind-tools su-exec && \
+    apk-install curl wget bash tree jq bind-tools su-exec gettext && \
     chmod u+s /sbin/su-exec && \
     curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz | tar -xz -C / && \
     curl -Ls https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip -o consul-template.zip && unzip consul-template.zip -d /usr/local/bin && \

--- a/versions/3.5/Dockerfile-tests
+++ b/versions/3.5/Dockerfile-tests
@@ -14,7 +14,8 @@ RUN exec 2>&1 && apk-install bind-tools bc jq \
     && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
 	&& rm -f bats.zip dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && mv /tests/consul-template/etc /etc/consul-template
+    && mv /tests/consul-template/etc /etc/consul-template \
+    && mv /tests/consul/etc /etc/consul
 
 
 CMD ["bash"]


### PR DESCRIPTION
Hey guys,

This is a PR to be able to run consul agent as a supervised service (S6) into a Docker container.

The motivation for this PR is specially to run Elasticsearch and setup the service discovery with Consul using the following plugin: 
  - https://github.com/vvanholl/elasticsearch-consul-discovery

Unfortunately the plugin now just support to join a Consul defined on localhost, that's why we need to run a Consul agent into the docker container.

Nik & Brat

