### PR TITLE
Added alpine version 3.7 image.

### DIFF
--- a/versions/3.7/Dockerfile
+++ b/versions/3.7/Dockerfile
@@ -1,0 +1,33 @@
+#
+# Base Alpine Linux image
+#
+
+FROM alpine:3.7
+MAINTAINER Bandsintown Devops Team "devops@bandsintown.com"
+
+ENV S6_OVERLAY_VERSION=1.19.1.1 GODNSMASQ_VERSION=1.0.7 CONSUL_TEMPLATE_VERSION=0.19.4 CONSUL_VERSION=0.8.4
+
+# Install root filesystem
+COPY rootfs /
+
+# Install base packages
+RUN apk update && apk upgrade && \
+    apk-install curl wget bash tree jq bind-tools su-exec && \
+    chmod u+s /sbin/su-exec && \
+    curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz | tar -xz -C / && \
+    curl -Ls https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip -o consul-template.zip && unzip consul-template.zip -d /usr/local/bin && \
+    curl -Ls https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip -o consul.zip && unzip consul.zip -d /usr/local/bin && \
+    curl -Ls https://github.com/janeczku/go-dnsmasq/releases/download/${GODNSMASQ_VERSION}/go-dnsmasq-min_linux-amd64 -o /usr/sbin/go-dnsmasq &&  \
+    rm -f consul* && \
+    chmod +x /usr/sbin/go-dnsmasq && \
+    echo -ne "Alpine Linux 3.7 image. (`uname -rsv`)\n" >> /root/.built && \
+    echo -ne "- with S6 Overlay: $S6_OVERLAY_VERSION, GoDnsMasq: $GODNSMASQ_VERSION, Consul Template: $CONSUL_TEMPLATE_VERSION, Consul: $CONSUL_VERSION\n" >> /root/.built
+
+# Disable S6 logs on stdout/stderr
+ENV S6_LOGGING=1
+
+# Enable S6 as default entrypoint
+ENTRYPOINT ["/init"]
+
+# Define bash as default command
+CMD ["bash"]

--- a/versions/3.7/Dockerfile
+++ b/versions/3.7/Dockerfile
@@ -12,6 +12,7 @@ COPY rootfs /
 
 # Install base packages
 RUN apk update && apk upgrade && \
+	apk add busybox && apk add busybox-extras && \
     apk-install curl wget bash tree jq bind-tools su-exec && \
     chmod u+s /sbin/su-exec && \
     curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz | tar -xz -C / && \

--- a/versions/3.7/Dockerfile-tests
+++ b/versions/3.7/Dockerfile-tests
@@ -1,0 +1,20 @@
+FROM bandsintown/alpine:3.7
+
+ENV BATS_VERSION=0.4.0 DOCKERIZE_VERSION=v0.2.0
+
+COPY tests /tests
+WORKDIR /tests
+
+RUN exec 2>&1 && apk-install bind-tools bc jq \
+    && curl -Ls https://codeload.github.com/sstephenson/bats/zip/v$BATS_VERSION -o /tmp/bats.zip \
+	&& cd /tmp \
+	&& unzip -q bats.zip \
+	&& ./bats-${BATS_VERSION}/install.sh /usr/local \
+	&& ln -sf /usr/local/libexec/bats /usr/local/bin/bats \
+    && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+	&& rm -f bats.zip dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && mv /tests/consul-template/etc /etc/consul-template
+
+
+CMD ["bash"]


### PR DESCRIPTION
I added a new Dockerfile and tests for v3.7 of alpine. This will then be used to create a new Node v10 image in docker-node. 

I ran the following commands and both images were created successfully:

`docker build -t bandsintown/alpine:3.7 -f ./versions/3.7/Dockerfile .`
`docker build -t bandsintown/alpine:3.7-tests -f ./versions/3.7/Dockerfile-tests .`