### PR TITLE
Update Buildkite pipelines to release a single version of the Docker images

### DIFF
--- a/.buildkite/pipeline.master.yml
+++ b/.buildkite/pipeline.master.yml
@@ -1,0 +1,44 @@
+steps:
+  - block: ":question::rocket: Do you want to release to Dockerhub?"
+    fields:
+      - select: Do you want to prepare a version for release?
+        key: "prepare-release"
+        options:
+          - label: "Yes"
+            value: "yes"
+          - label: "No"
+            value: "no"
+
+  - label: Prepare Dockerhub release
+    if: $(buildkite-agent meta-data get prepare-release) == "yes"
+    command: buildkite-agent pipeline upload .buildkite/pipeline.prepare-release.yml
+
+  - block: ":github: Prepare Github Release"
+    prompt: Fill out the details for release
+    fields:
+      - text: Release name
+        key: release-name
+        required: true
+        hint: |
+          It's common practice to prefix your version names with the letter v.
+          Some good tag names might be v1.0 or v2.3.4.
+          If the tag isn't meant for production use, add a pre-release version
+          after the version name. Some good pre-release versions might be
+          v0.2-alpha or v5.9-beta.3.
+      - text: Describe this release
+        key: release-notes
+        required: false
+        hint: List of what's changed in this release
+      - select: Release type
+        key: release-type
+        default: draft
+        options:
+        - label: Draft
+          value: draft
+        - label: Pre-release
+          value: pre-release
+        - label: Release
+          value: release
+
+  - label: ":github: Create Github release"
+    command: .buildkite/release.sh

--- a/.buildkite/pipeline.prepare-release.yml
+++ b/.buildkite/pipeline.prepare-release.yml
@@ -1,0 +1,54 @@
+env:
+  PIPELINE_NAME: docker-alpine
+
+steps:
+  - input: What version do you want to build and release?
+    fields:
+      - select: Release Version
+        key: release-version
+        hint: "Only the 5 latest versions are shown"
+        required: true
+        options:
+          - label: "v3.19.1"
+            value: "3.19.1"
+          - label: "v3.17.3"
+            value: "3.17.3"
+          - label: "v3.15.0"
+            value: "3.15.0"
+          - label: "v3.7"
+            value: "3.7"
+          - label: "v3.6"
+            value: "3.6"
+
+  - block: Tag version as latest?
+    fields:
+      - select: Tag this version as latest?
+        key: version-is-latest
+        required: true
+        default: "no"
+        options:
+          - label: "Yes"
+            value: "yes"
+          - label: "No"
+            value: "no"
+
+  - wait
+
+  - label: Trigger Build and Release pipeline
+    command: |
+      VERSION="$$(buildkite-agent meta-data get release-version --default 'NA')"
+      VERSION_IS_LATEST="$$(buildkite-agent meta-data get version-is-latest --default 'NA')"
+
+      cat <<- YAML | buildkite-agent pipeline upload
+      steps:
+        - trigger: ${PIPELINE_NAME}
+          async: true
+          label: ":construction::building_construction: Trigger deploy for version $$VERSION"
+          build:
+            commit: "${BUILDKITE_COMMIT}"
+            branch: "${BUILDKITE_BRANCH}"
+            env:
+              VERSION: "$$VERSION"
+              VERSION_IS_LATEST: "$$VERSION_IS_LATEST"
+              DEPLOY_SERVICE: release
+      YAML

--- a/.buildkite/pipeline.pull_request.yml
+++ b/.buildkite/pipeline.pull_request.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: ":docker: Prepare Dockerhub release"
+    command: buildkite-agent pipeline upload .buildkite/pipeline.prepare-release.yml

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,0 +1,23 @@
+env:
+  IMAGE: bandsintown/alpine
+
+steps:
+  - label: ":docker: Build and Push Alpine v${VERSION}"
+    if: build.env("VERSION") != "NA"
+    plugins:
+      - docker-compose#v5.2.0:
+          cli-version: 1
+          buildkit: false
+          build: alpine
+          push:
+            - alpine:${IMAGE}:${VERSION}
+            - alpine:${IMAGE}:${VERSION}-${BUILDKITE_COMMIT:0:7}
+
+  - label: ":docker: Tag as latest and Push Alpine v${VERSION}"
+    if: build.env("VERSION_IS_LATEST") == "yes"
+    plugins:
+      - docker-compose#v5.2.0:
+          cli-version: 1
+          buildkit: false
+          push:
+            - alpine:${IMAGE}:latest

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,30 @@
+steps:
+  # Upload pipeline for branch `master`.
+  # Conditions:
+  #   Build created from branch `master`
+  #   Not "triggered" by other builds.
+  - command: "buildkite-agent pipeline upload .buildkite/pipeline.master.yml"
+    label: ":pipeline: Master pipeline"
+    if: |
+      build.branch == "master" &&
+      build.source != "trigger_job"
+
+  # Upload pipeline for Pull Requests.
+  # Conditions:
+  #   Not created from the `master` branch.
+  #   Not "triggered" by other builds.
+  - command: "buildkite-agent pipeline upload .buildkite/pipeline.pull_request.yml"
+    label: ":pipeline: Pull Request pipeline"
+    if: |
+      build.branch != "master" &&
+      build.source != "trigger_job"
+
+  # Upload pipeline specified by $DEPLOY_SERVICE.
+  # Conditions:
+  #   Build triggered by other builds.
+  #   $DEPLOY_SERVICE is specified.
+  - command: "buildkite-agent pipeline upload .buildkite/pipeline.${DEPLOY_SERVICE}.yml"
+    label: ":pipeline: Triggered pipeline for ${DEPLOY_SERVICE}"
+    if: |
+      build.source == "trigger_job" &&
+      build.env("DEPLOY_SERVICE") != "NA"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  alpine:
+    build:
+      context: .
+      dockerfile: ./versions/${VERSION}/Dockerfile


### PR DESCRIPTION
## Use Buildkite to select the version for release

The Buildkite pipeline will ask what version we want to release. 
On the prompt only the **5 latest versions** are displayed. When we need 
to build a new version the pipeline step also needs to be updated to reflect 
the change.

## Use [Docker Compose Buildkite plugin](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin) to build images

Because we have `docker-compose` v1 installed, for the `docker-compose` 
plugin we have to specify the `cli_version=1` argument to use the 
`docker-compose` command, instead of the newer `docker compose`.

This also updates the pipeline workflow:

1. `.buildkite/pipeline.yml` is now the entry point for new builds.
2. `.buildkite/pipeline.master.yml` used for the branch `master`, can
   build and release images and create a Github release.
3. `./buildkite/pipeline.pull_request.yml` used for Pull Requests, can
   build and release images, doesn't create a Github release.